### PR TITLE
feat: asynchronous gRPC client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,10 +34,14 @@ add_library(grpc_wrapper
         ${PROTO_IMPORT_FILES}
         src/grpc_client_wrapper.cpp src/grpc_client_wrapper.h
         ${PROTO_GEN_FILES}
+        src/grpc_client_wrapper_async.cpp
+        src/grpc_client_wrapper_async.h
+        ${CPPCORO_INCLUDE_DIR}
 )
 target_link_libraries(grpc_wrapper
         ${Protobuf_LIBRARIES}
         gRPC::grpc++
+        cppcoro
 )
 set_target_properties(grpc_wrapper PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
@@ -56,6 +60,7 @@ add_executable(grpc_experiment
 target_link_libraries(grpc_experiment
         #        ${LIBPURPLE_LIBRARIES}
         cppcoro
+        jsoncpp_lib
         grpc_wrapper
 )
 

--- a/DEVELOPMENT_NOTES.md
+++ b/DEVELOPMENT_NOTES.md
@@ -77,6 +77,18 @@ Not that many functions immediately in libpurple plugin instantiation:
 
 [gRPC streaming client](https://stackoverflow.com/questions/71909245/how-to-use-grpc-c-clientasyncreadermessage-for-server-side-streams)
 
+#### Coroutines
+
+Avoid using multiple threads (even for gRPC completion queue), GTK hits assertions otherwise: https://github.com/DeaDBeeF-Player/deadbeef/issues/2112#issuecomment-480630111
+
+```
+Bail out! Gtk:ERROR:gtktextview.c:3571:gtk_text_view_validate_onscreen: assertion failed: (text_view->onscreen_validated)
+# (18:01:15) dummy: receive_messages done
+got completion queue event #0x4b => ok
+**
+Gtk:ERROR:gtktextview.c:3571:gtk_text_view_va
+```
+
 #### libpurple
 
 ```cpp

--- a/DEVELOPMENT_NOTES.md
+++ b/DEVELOPMENT_NOTES.md
@@ -75,6 +75,10 @@ https://stackoverflow.com/questions/52533396/cmake-cant-find-protobuf-protobuf-g
 
 Not that many functions immediately in libpurple plugin instantiation:
 
+[gRPC streaming client](https://stackoverflow.com/questions/71909245/how-to-use-grpc-c-clientasyncreadermessage-for-server-side-streams)
+
+#### libpurple
+
 ```cpp
 	steam_list_icon,           /* list_icon */
 	steam_list_emblem,         /* list_emblems */

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# pidgin-steam: Steam plugin for Pidgin
+# pidgin-steam-cpp: Steam plugin for Pidgin
 
 WIP. Intended to replace the now defunct https://github.com/EionRobb/pidgin-opensteamworks.
 
@@ -9,6 +9,7 @@ This branch consists of:
 ## Build
 
 Dependencies:
+* C++20
 * CMake
 * protobuf
   * protoc
@@ -41,7 +42,10 @@ Run pidgin:
 
 ## TODO
 
-- [ ] make gRPC client asynchronous, e.g. with cppcoro
+- [X] make gRPC client asynchronous, e.g. with cppcoro
+- [ ] fix coroutine crashes
+  - [ ] on `steam_close`
+  - [ ] use multithreading for gRPC client
 - [ ] More robust handling of gRPC errors
 - [ ] cleanups
   - [ ] better build system?

--- a/nodejs/src/server.ts
+++ b/nodejs/src/server.ts
@@ -375,11 +375,16 @@ function messageRoute(router: ConnectRouter) {
                 console.log("Friend", steamId, friend.player_name, personaState)
                 let isOnline = personaState !== SteamUser.EPersonaState.Offline;
                 // console.log("isOnline", isOnline);
+                console.log(friend.player_name, friend.avatar_url_icon);
                 return new Persona({
                     id: steamId,
                     name: friend.player_name,
                     personaState: (personaState as unknown) as PersonaState,
-                    // avatarUrl: friend.avatar_url_full,
+                    avatarUrl: {
+                        icon: friend.avatar_url_icon,
+                        medium: friend.avatar_url_medium,
+                        full: friend.avatar_url_full,
+                    },
                     // lastLogoff: Timestamp.fromDate(friend.last_logoff),
                     // lastLogon: Timestamp.fromDate(friend.last_logon),
                     // lastSeenOnline: Timestamp.fromDate(friend.last_seen_online),

--- a/nodejs/src/server.ts
+++ b/nodejs/src/server.ts
@@ -88,7 +88,6 @@ let activeSessions: Map<string, SessionWrapper> = new Map();
 function authRoute(router: ConnectRouter) {
     router.service(AuthService, {
         async authenticate(call) {
-            // console.log("Received", call.toJson());
             let sessionKey: string;
             let wrapper: SessionWrapper;
             let isNew: boolean;
@@ -314,12 +313,10 @@ function messageRoute(router: ConnectRouter) {
             var startTime = call.startTimestamp?.toDate();
             var lastTime = call.lastTimestamp?.toDate();
             for (var i = 0; i < 10; ++i) {
-                console.log("lastTime", lastTime)
                 let { messages, more_available } = await client.chat.getFriendMessageHistory(steamId, {
                     startTime: startTime,
                     lastTime: lastTime,
                 });
-                console.log("more_available", more_available);
                 allMessages.push(...messages.filter((message) => message.server_timestamp.getTime() > (call.startTimestamp?.toDate().getTime() || 0)));
                 if (!more_available) {
                     break;
@@ -332,14 +329,13 @@ function messageRoute(router: ConnectRouter) {
             allMessages.sort((a, b) => a.server_timestamp.getTime() - b.server_timestamp.getTime());
 
             for await (let message of allMessages) {
-                console.log("Message", message);
                 yield new ResponseMessage({
                     senderId: message.sender.getSteamID64(),
                     message: message.message,
                     timestamp: Timestamp.fromDate(message.server_timestamp),
                 });
             }
-            console.log("Done polling messages")
+            console.log(`Done polling ${allMessages.length} messages`)
         },
         async getFriendsList(call: FriendsListRequest) {
             console.log("Received", call.getType().typeName, call.toJson());
@@ -366,16 +362,11 @@ function messageRoute(router: ConnectRouter) {
                 if (!friend) {
                     throw new Error("Invalid steamId");
                 }
-                // console.log("Friend", steamId, friend);
                 var personaState = friend.persona_state;
                 if (personaState === undefined || personaState === null) {
                     personaState = SteamUser.EPersonaState.Offline;
                 }
-                // console.log("state", personaState, SteamUser.EPersonaState.Offline);
-                console.log("Friend", steamId, friend.player_name, personaState)
                 let isOnline = personaState !== SteamUser.EPersonaState.Offline;
-                // console.log("isOnline", isOnline);
-                console.log(friend.player_name, friend.avatar_url_icon);
                 return new Persona({
                     id: steamId,
                     name: friend.player_name,

--- a/protobufs_src/comm_protobufs/message.proto
+++ b/protobufs_src/comm_protobufs/message.proto
@@ -1,12 +1,16 @@
 syntax = "proto3";
 package steam;
 import "google/protobuf/timestamp.proto";
+import "google/protobuf/empty.proto";
 
 // Send and receive messages from a single Steam user
 service MessageService {
     rpc SendChatMessage (MessageRequest) returns (SendMessageResult);
     rpc PollChatMessages (PollRequest) returns (stream ResponseMessage);
+    rpc StreamFriendMessages (StreamChatRequest) returns (stream ResponseMessage);
     rpc GetFriendsList (FriendsListRequest) returns (FriendsListResponse);
+    rpc GetActiveFriendMessageSessions (ActiveMessageSessionsRequest) returns (ActiveMessageSessionResponse);
+    rpc AckFriendMessage (AckFriendMessageRequest) returns (google.protobuf.Empty);
 }
 
 message MessageRequest {
@@ -34,6 +38,10 @@ message PollRequest {
     string sessionKey = 2;
     optional google.protobuf.Timestamp startTimestamp = 3;
     optional google.protobuf.Timestamp lastTimestamp = 4;
+}
+
+message StreamChatRequest {
+    string sessionKey = 1;
 }
 
 message ResponseMessage {
@@ -75,4 +83,27 @@ message Persona {
 message FriendsListResponse {
     Persona user = 1;
     repeated Persona friends = 2;
+}
+
+message ActiveMessageSessionsRequest {
+    string sessionKey = 1;
+    google.protobuf.Timestamp since = 2;
+}
+
+message ActiveMessageSession {
+    string targetId = 1;
+    google.protobuf.Timestamp lastMessageTimestamp = 2;
+    google.protobuf.Timestamp lastViewTimestamp = 3;
+    int32 unreadCount = 4;
+}
+
+message ActiveMessageSessionResponse {
+    repeated ActiveMessageSession sessions = 1;
+    google.protobuf.Timestamp timestamp = 2;
+}
+
+message AckFriendMessageRequest {
+    string sessionKey = 1;
+    string targetId = 2;
+    google.protobuf.Timestamp lastTimestamp = 3;
 }

--- a/protobufs_src/comm_protobufs/message.proto
+++ b/protobufs_src/comm_protobufs/message.proto
@@ -87,7 +87,7 @@ message FriendsListResponse {
 
 message ActiveMessageSessionsRequest {
     string sessionKey = 1;
-    google.protobuf.Timestamp since = 2;
+    optional google.protobuf.Timestamp since = 2;
 }
 
 message ActiveMessageSession {

--- a/protobufs_src/comm_protobufs/message.proto
+++ b/protobufs_src/comm_protobufs/message.proto
@@ -57,10 +57,19 @@ enum PersonaState {  // mirrors SteamUser.EPersonaState
     INVISIBLE = 7;
 }
 
+message AvatarUrl {
+    string icon = 1;
+    string medium = 2;
+    string full = 3;
+}
+
 message Persona {
     string id = 1;
     string name = 2;
     PersonaState personaState = 3;
+    optional int32 gameid = 4;
+    optional string gameExtraInfo = 5;
+    AvatarUrl avatarUrl = 6;
 }
 
 message FriendsListResponse {

--- a/src/grpc_client_wrapper.cpp
+++ b/src/grpc_client_wrapper.cpp
@@ -7,8 +7,6 @@
 #include "../protobufs/comm_protobufs/auth.grpc.pb.h"
 
 namespace SteamClient {
-    ClientWrapper::~ClientWrapper() = default;
-
     struct ClientWrapper::impl {
         std::shared_ptr<grpc::Channel> channel;
         std::unique_ptr<steam::AuthService::Stub> authStub;
@@ -175,6 +173,8 @@ namespace SteamClient {
             }
         }
     };
+
+    ClientWrapper::~ClientWrapper() = default;
 
     ClientWrapper::ClientWrapper(const std::string &url) {
         pImpl = std::make_unique<impl>(url);

--- a/src/grpc_client_wrapper.cpp
+++ b/src/grpc_client_wrapper.cpp
@@ -86,6 +86,15 @@ namespace SteamClient {
         }
 
         FriendsList getFriendsList() {
+            auto convert = [](const steam::Persona &user) -> Buddy {
+                const auto& avatarUrl = user.avatarurl();
+                return {
+                    user.name(), user.id(), (PersonaState) (int) user.personastate(),
+                    {}, "",  // TODO: get rich presence
+                    {avatarUrl.icon(), avatarUrl.medium(), avatarUrl.full()}
+                };
+            };
+
             steam::FriendsListRequest request;
             request.set_sessionkey(sessionKey.value());
 
@@ -101,10 +110,9 @@ namespace SteamClient {
             std::cout << "Friends: " << response.friends_size() << std::endl;
             std::vector<Buddy> friends;
             for (auto &x: response.friends()) {
-                friends.emplace_back(x.name(), x.id(), (PersonaState) (int) x.personastate());
+                friends.emplace_back(convert(x));
             }
-            auto me = response.user();
-            return {std::optional<Buddy>({me.name(), me.id(), (PersonaState) (int) me.personastate()}), friends};
+            return {std::optional<Buddy>(convert(response.user())), friends};
         }
 
         static google::protobuf::Timestamp *

--- a/src/grpc_client_wrapper.cpp
+++ b/src/grpc_client_wrapper.cpp
@@ -189,10 +189,12 @@ namespace SteamClient {
             }
         }
 
-        ActiveMessageSessions getActiveMessageSessions(int64_t sinceTimestampMs) {
+        ActiveMessageSessions getActiveMessageSessions(std::optional<int64_t> sinceTimestampMs) {
             steam::ActiveMessageSessionsRequest request;
             request.set_sessionkey(sessionKey.value());
-            request.set_allocated_since(make_timestamp_protobuf(sinceTimestampMs));
+            if (sinceTimestampMs.has_value()) {
+                request.set_allocated_since(make_timestamp_protobuf(sinceTimestampMs.value()));
+            }
 
             grpc::ClientContext context;
             steam::ActiveMessageSessionResponse response;
@@ -258,7 +260,7 @@ namespace SteamClient {
         return pImpl->sendMessage(id, message);
     }
 
-    ActiveMessageSessions ClientWrapper::getActiveMessageSessions(int64_t sinceTimestampMs) {
+    ActiveMessageSessions ClientWrapper::getActiveMessageSessions(std::optional<int64_t> sinceTimestampMs) {
         return pImpl->getActiveMessageSessions(sinceTimestampMs);
     }
 

--- a/src/grpc_client_wrapper.h
+++ b/src/grpc_client_wrapper.h
@@ -64,6 +64,17 @@ namespace SteamClient {
         std::vector<Buddy> buddies;
     };
 
+    struct ActiveMessageSessions {
+        struct Session {
+            std::string id;
+            int64_t lastMessageTimestampNs;
+            int64_t lastViewedTimestampNs;
+            int unreadMessageCount;
+        };
+        std::vector<Session> session;
+        std::optional<int64_t> timestamp;
+    };
+
     class ClientWrapper {
         struct impl;
         std::unique_ptr<impl> pImpl;
@@ -82,6 +93,10 @@ namespace SteamClient {
                                          std::optional<int64_t> lastTimestampNs = std::nullopt);
 
         SendMessageCode sendMessage(const std::string &id, const std::string &message);
+
+        ActiveMessageSessions getActiveMessageSessions(int64_t sinceTimestampMs);
+
+        bool ackFriendMessage(const std::string &id, int64_t timestampNs);
 
         void resetSessionKey();
 

--- a/src/grpc_client_wrapper.h
+++ b/src/grpc_client_wrapper.h
@@ -94,7 +94,7 @@ namespace SteamClient {
 
         SendMessageCode sendMessage(const std::string &id, const std::string &message);
 
-        ActiveMessageSessions getActiveMessageSessions(int64_t sinceTimestampMs);
+        ActiveMessageSessions getActiveMessageSessions(std::optional<int64_t> sinceTimestampMs = std::nullopt);
 
         bool ackFriendMessage(const std::string &id, int64_t timestampNs);
 

--- a/src/grpc_client_wrapper.h
+++ b/src/grpc_client_wrapper.h
@@ -20,6 +20,12 @@ namespace SteamClient {
         INVISIBLE = 7,
     };
 
+    struct AvatarUrl {
+        std::string icon;
+        std::string medium;
+        std::string full;
+    };
+
     struct Buddy {
         std::string nickname;
         std::string id;
@@ -28,6 +34,8 @@ namespace SteamClient {
         // rich presence
         std::optional<int> gameid;
         std::string gameExtraInfo;
+
+        AvatarUrl avatarUrl;
     };
 
     struct Message {

--- a/src/grpc_client_wrapper_async.cpp
+++ b/src/grpc_client_wrapper_async.cpp
@@ -238,6 +238,8 @@ namespace SteamClient {
         }
     };
 
+    AsyncClientWrapper::~AsyncClientWrapper() = default;
+
     cppcoro::task<AuthResponseState>
     AsyncClientWrapper::authenticate(const std::string &username, const std::string &password,
                                      const std::optional<std::string> &steamGuardCode) {
@@ -259,9 +261,15 @@ namespace SteamClient {
         return pImpl->sendMessage(id, message);
     }
 
+    void AsyncClientWrapper::resetSessionKey() {
+        pImpl->sessionKey = std::nullopt;
+    }
+
+    bool AsyncClientWrapper::shouldReset() {
+        return !pImpl->lastSuccessState;
+    }
+
     AsyncClientWrapper::AsyncClientWrapper::AsyncClientWrapper(const std::string &address) {
         pImpl = std::make_unique<impl>(address);
     }
-
-    AsyncClientWrapper::~AsyncClientWrapper() = default;
 } // SteamClient

--- a/src/grpc_client_wrapper_async.cpp
+++ b/src/grpc_client_wrapper_async.cpp
@@ -253,10 +253,12 @@ namespace SteamClient {
             }
         }
 
-        cppcoro::task<ActiveMessageSessions> getActiveMessageSessions(int64_t sinceTimestampMs) {
+        cppcoro::task<ActiveMessageSessions> getActiveMessageSessions(std::optional<int64_t> sinceTimestampMs) {
             steam::ActiveMessageSessionsRequest request;
             request.set_sessionkey(sessionKey.value());
-            request.set_allocated_since(make_timestamp_protobuf(sinceTimestampMs));
+            if (sinceTimestampMs.has_value()) {
+                request.set_allocated_since(make_timestamp_protobuf(sinceTimestampMs.value()));
+            }
 
             grpc::ClientContext context;
             steam::ActiveMessageSessionResponse response;
@@ -333,7 +335,7 @@ namespace SteamClient {
     }
 
     cppcoro::task<ActiveMessageSessions>
-    AsyncClientWrapper::getActiveMessageSessions(int64_t sinceTimestampMs) {
+    AsyncClientWrapper::getActiveMessageSessions(std::optional<int64_t> sinceTimestampMs) {
         return pImpl->getActiveMessageSessions(sinceTimestampMs);
     }
 

--- a/src/grpc_client_wrapper_async.cpp
+++ b/src/grpc_client_wrapper_async.cpp
@@ -1,0 +1,267 @@
+#include "grpc_client_wrapper.h"
+#include "grpc_client_wrapper_async.h"
+#include "coro_utils.h"
+#include <grpcpp/grpcpp.h>
+#include <atomic>
+#include <thread>
+#include "../protobufs/comm_protobufs/message.pb.h"
+#include "../protobufs/comm_protobufs/message.grpc.pb.h"
+#include "../protobufs/comm_protobufs/auth.pb.h"
+#include "../protobufs/comm_protobufs/auth.grpc.pb.h"
+#include "cppcoro/sync_wait.hpp"
+
+namespace SteamClient {
+    struct grpc_client_wrapper_async::impl {
+        std::shared_ptr<grpc::Channel> channel;
+        std::unique_ptr<steam::AuthService::Stub> authStub;
+        std::unique_ptr<steam::MessageService::Stub> messageStub;
+
+        grpc::CompletionQueue completionQueue;
+        std::atomic<size_t> tagCounter{0};
+        std::atomic<bool> shutdown{false};
+        std::jthread completionQueueThread;
+        std::map<size_t, TaskCompletionSource<bool>> callbacks;
+
+        SteamClient::AuthResponseState lastAuthResponseState = AUTH_UNKNOWN_FAILURE;
+        bool lastSuccessState = false;
+        std::optional<std::string> sessionKey;
+
+        explicit impl(const std::string &address) {
+            channel = grpc::CreateChannel(address, grpc::InsecureChannelCredentials());
+            authStub = steam::AuthService::NewStub(channel);
+            messageStub = steam::MessageService::NewStub(channel);
+
+            completionQueueThread = std::jthread([this]() {
+                cppcoro::sync_wait(std::move(run_cq()));
+            });
+        }
+
+        ~impl() {
+            shutdown = true;
+            completionQueue.Shutdown();
+            completionQueueThread.join();
+        }
+
+        cppcoro::task<void> run_cq() {
+            std::cout << "starting completion queue" << std::endl;
+            void *tag;
+            bool ok;
+            while (completionQueue.Next(&tag, &ok)) {
+                std::cout << "got completion queue event #" << tag << " => " << (ok ? "ok" : "not ok") << std::endl;
+                auto &token = callbacks.at(reinterpret_cast<size_t>(tag));
+                co_await token.sequenced_set_result(ok);
+            }
+            std::cout << "stopping completion queue" << std::endl;
+        }
+
+        template<typename Rpc, typename Response>
+        cppcoro::task<bool> run_call(Rpc &rpc, Response &response, grpc::Status &status) {
+            auto tag = tagCounter++;
+            auto &token = callbacks.emplace(std::piecewise_construct, std::forward_as_tuple(tag),
+                                            std::forward_as_tuple()).first->second;
+            rpc->Finish(&response, &status, reinterpret_cast<void *>(tag));
+            bool ok = co_await token.get_task();
+            callbacks.erase(tag);
+            co_return ok;
+        }
+
+        cppcoro::task<std::tuple<AuthResponseState, std::string>>
+        _authenticate(const std::string &username, const std::string &password,
+                      const std::optional<std::string> &steamGuardCode) {
+            steam::AuthRequest request;
+            request.set_username(username);
+            request.set_password(password);
+            if (steamGuardCode.has_value()) {
+                request.set_steamguardcode(steamGuardCode.value());
+            }
+            if (sessionKey.has_value()) {
+                request.set_sessionkey(sessionKey.value());
+            }
+
+            grpc::ClientContext context;
+            steam::AuthResponse response;
+            auto rpc = authStub->AsyncAuthenticate(&context, request, &completionQueue);
+            if (grpc::Status status; !co_await run_call(rpc, response, status)) {
+                co_return std::make_tuple(lastAuthResponseState, "");
+            }
+
+            switch (response.reason()) {
+                case steam::AuthResponse_AuthState_SUCCESS:
+                    std::cout << "Auth successful" << std::endl;
+                    std::cout << "Session key " << response.sessionkey() << std::endl;
+                    co_return std::make_tuple(AUTH_SUCCESS, response.sessionkey());
+                case steam::AuthResponse_AuthState_INVALID_CREDENTIALS:
+                    std::cout << "Auth failed (invalid credentials)" << std::endl;
+                    co_return std::make_tuple(AUTH_INVALID_CREDENTIALS, response.sessionkey());
+                case steam::AuthResponse_AuthState_STEAM_GUARD_CODE_REQUEST:
+                    std::cout << "Auth failed (pending Steam Guard code)" << std::endl;
+                    co_return std::make_tuple(AUTH_PENDING_STEAM_GUARD_CODE, response.sessionkey());
+                default:
+                    std::cout << "Auth failed (unknown failure)" << std::endl;
+                    co_return std::make_tuple(AUTH_UNKNOWN_FAILURE, response.sessionkey());
+            }
+        }
+
+        cppcoro::task<AuthResponseState>
+        authenticate(const std::string &username, const std::string &password,
+                     const std::optional<std::string> &steamGuardCode) {
+            auto [state, newSessionKey] = co_await _authenticate(username, password, steamGuardCode);
+            this->lastAuthResponseState = state;
+            switch (state) {
+                case AUTH_SUCCESS:
+                    this->lastSuccessState = true;
+                    this->sessionKey = newSessionKey;
+                    break;
+                case AUTH_INVALID_CREDENTIALS:
+                    this->lastSuccessState = false;
+                    this->sessionKey = std::nullopt;
+                    break;
+                case AUTH_PENDING_STEAM_GUARD_CODE:
+                    this->lastSuccessState = true;
+                    this->sessionKey = newSessionKey;
+                    break;
+                case AUTH_UNKNOWN_FAILURE:
+                    this->lastSuccessState = false;
+                    this->sessionKey = std::nullopt;
+                    break;
+            }
+            co_return state;
+        }
+
+        cppcoro::task<FriendsList> getFriendsList() {
+            steam::FriendsListRequest request;
+            request.set_sessionkey(sessionKey.value());
+
+            steam::FriendsListResponse response;
+            grpc::ClientContext context;
+            auto rpc = messageStub->AsyncGetFriendsList(&context, request, &completionQueue);
+            if (grpc::Status status; !co_await run_call(rpc, response, status)) {
+                std::cout << "GetFriendsList failed (gRPC failure)" << std::endl;
+                std::cout << status.error_code() << ": " << status.error_message() << std::endl;
+                co_return FriendsList{std::nullopt, {}};
+            }
+            std::cout << "GetFriends successful" << std::endl;
+            std::cout << "Friends: " << response.friends_size() << std::endl;
+            std::vector<Buddy> friends;
+            for (auto &x: response.friends()) {
+                friends.emplace_back(x.name(), x.id(), (PersonaState) (int) x.personastate());
+            }
+            auto me = response.user();
+            co_return FriendsList{std::optional<Buddy>({me.name(), me.id(), (PersonaState) (int) me.personastate()}),
+                                  friends};
+        }
+
+        static google::protobuf::Timestamp *
+        set_timestamp_protobuf(google::protobuf::Timestamp *timestamp, int64_t timestamp_ns) {
+            timestamp->set_seconds(timestamp_ns / 1000000000LL);  // Convert nanoseconds to seconds
+            timestamp->set_nanos((int32_t) (timestamp_ns % 1000000000LL));  // Get remaining nanoseconds
+            return timestamp;
+        }
+
+        // TODO: handle streaming responses in completion queue thread
+        cppcoro::task<std::vector<Message>>
+        getMessages(const std::string &id, std::optional<int64_t> startTimestampNs = std::nullopt,
+                    std::optional<int64_t> lastTimestampNs = std::nullopt) {
+            steam::PollRequest request;
+            request.set_sessionkey(sessionKey.value());
+            request.set_targetid(id);
+            if (startTimestampNs.has_value()) {
+                auto *timestamp = new google::protobuf::Timestamp();
+                request.set_allocated_starttimestamp(set_timestamp_protobuf(timestamp, startTimestampNs.value()));
+            }
+            if (lastTimestampNs.has_value()) {
+                auto *timestamp = new google::protobuf::Timestamp();
+                request.set_allocated_lasttimestamp(set_timestamp_protobuf(timestamp, lastTimestampNs.value()));
+            }
+            grpc::ClientContext context;
+            grpc::Status status;
+            auto tag = tagCounter++;
+            auto stream = messageStub->AsyncPollChatMessages(&context, request, &completionQueue,
+                                                             reinterpret_cast<void *>(tag));
+            auto &token = callbacks.emplace(std::piecewise_construct, std::forward_as_tuple(tag),
+                                            std::forward_as_tuple()).first->second;
+            std::vector<Message> messages;
+            if (co_await token.get_task()) {  // StartCall response
+                while (true) {
+                    steam::ResponseMessage response;
+                    stream->Read(&response, reinterpret_cast<void *>(tag));
+                    if (!co_await token.get_task()) {
+                        break;
+                    }
+
+                    Message message;
+                    message.senderId = response.senderid();  // TODO: send persona info for mapping
+                    message.message = response.message();
+                    message.timestamp_ns = response.timestamp().seconds() * 1000000000LL + response.timestamp().nanos();
+                    std::cout << "message: " << message.senderId << " " << message.message << " "
+                              << message.timestamp_ns << std::endl;
+                    messages.push_back(message);
+                }
+            } else {
+                stream->Finish(&status, reinterpret_cast<void *>(tag));
+            }
+            // TODO: check exception handling
+            callbacks.erase(tag);
+            co_return messages;
+        }
+
+        cppcoro::task<SendMessageCode> sendMessage(const std::string &id, const std::string &message) {
+            steam::MessageRequest request;
+            request.set_sessionkey(sessionKey.value());
+            request.set_targetid(id);
+            request.set_message(message);
+            grpc::ClientContext context;
+            steam::SendMessageResult response;
+            auto rpc = messageStub->AsyncSendChatMessage(&context, request, &completionQueue);
+            if (grpc::Status status; !co_await run_call(rpc, response, status)) {
+                std::cout << "SendMessage failed (gRPC failure)" << std::endl;
+                std::cout << status.error_code() << ": " << status.error_message() << std::endl;
+                co_return SEND_UNKNOWN_FAILURE;
+            }
+            switch (response.reason()) {
+                case steam::SendMessageResult_SendMessageResultCode_SUCCESS:
+                    std::cout << "SendMessage successful" << std::endl;
+                    co_return SEND_SUCCESS;
+                case steam::SendMessageResult_SendMessageResultCode_INVALID_SESSION_KEY:
+                    std::cout << "SendMessage failed (invalid session key)" << std::endl;
+                    co_return SEND_INVALID_SESSION_KEY;
+                case steam::SendMessageResult_SendMessageResultCode_INVALID_TARGET_ID:
+                    std::cout << "SendMessage failed (invalid target ID)" << std::endl;
+                    co_return SEND_INVALID_TARGET_ID;
+                case steam::SendMessageResult_SendMessageResultCode_INVALID_MESSAGE:
+                    std::cout << "SendMessage failed (invalid message)" << std::endl;
+                    co_return SEND_INVALID_MESSAGE;
+                default:
+                    std::cout << "SendMessage failed (unknown failure)" << std::endl;
+                    co_return SEND_UNKNOWN_FAILURE;
+            }
+        }
+    };
+
+    cppcoro::task<AuthResponseState>
+    grpc_client_wrapper_async::authenticate(const std::string &username, const std::string &password,
+                                            const std::optional<std::string> &steamGuardCode) {
+        return pImpl->authenticate(username, password, steamGuardCode);
+    }
+
+    cppcoro::task<FriendsList> grpc_client_wrapper_async::getFriendsList() {
+        return pImpl->getFriendsList();
+    }
+
+    cppcoro::task<std::vector<Message>>
+    grpc_client_wrapper_async::getMessages(const std::string &id, std::optional<int64_t> startTimestampNs,
+                                           std::optional<int64_t> lastTimestampNs) {
+        return pImpl->getMessages(id, startTimestampNs, lastTimestampNs);
+    }
+
+    cppcoro::task<SendMessageCode>
+    grpc_client_wrapper_async::sendMessage(const std::string &id, const std::string &message) {
+        return pImpl->sendMessage(id, message);
+    }
+
+    grpc_client_wrapper_async::grpc_client_wrapper_async::grpc_client_wrapper_async(const std::string &address) {
+        pImpl = std::make_unique<impl>(address);
+    }
+
+    grpc_client_wrapper_async::~grpc_client_wrapper_async() = default;
+} // SteamClient

--- a/src/grpc_client_wrapper_async.cpp
+++ b/src/grpc_client_wrapper_async.cpp
@@ -87,8 +87,10 @@ namespace SteamClient {
             grpc::ClientContext context;
             steam::AuthResponse response;
             auto rpc = authStub->AsyncAuthenticate(&context, request, &completionQueue);
-            if (grpc::Status status; !co_await run_call(rpc, response, status)) {
-                co_return std::make_tuple(lastAuthResponseState, "");
+            if (grpc::Status status; !co_await run_call(rpc, response, status) || !status.ok()) {
+                std::cout << "Auth failed (gRPC failure)" << std::endl;
+                std::cout << status.error_code() << ": " << status.error_message() << std::endl;
+                co_return std::make_tuple(AUTH_UNKNOWN_FAILURE, "");
             }
 
             switch (response.reason()) {
@@ -141,7 +143,7 @@ namespace SteamClient {
             steam::FriendsListResponse response;
             grpc::ClientContext context;
             auto rpc = messageStub->AsyncGetFriendsList(&context, request, &completionQueue);
-            if (grpc::Status status; !co_await run_call(rpc, response, status)) {
+            if (grpc::Status status; !co_await run_call(rpc, response, status) || !status.ok()) {
                 std::cout << "GetFriendsList failed (gRPC failure)" << std::endl;
                 std::cout << status.error_code() << ": " << status.error_message() << std::endl;
                 co_return FriendsList{std::nullopt, {}};
@@ -219,7 +221,7 @@ namespace SteamClient {
             grpc::ClientContext context;
             steam::SendMessageResult response;
             auto rpc = messageStub->AsyncSendChatMessage(&context, request, &completionQueue);
-            if (grpc::Status status; !co_await run_call(rpc, response, status)) {
+            if (grpc::Status status; !co_await run_call(rpc, response, status) || !status.ok()) {
                 std::cout << "SendMessage failed (gRPC failure)" << std::endl;
                 std::cout << status.error_code() << ": " << status.error_message() << std::endl;
                 co_return SEND_UNKNOWN_FAILURE;

--- a/src/grpc_client_wrapper_async.cpp
+++ b/src/grpc_client_wrapper_async.cpp
@@ -52,11 +52,12 @@ namespace SteamClient {
                     co_await ioService.schedule_after(std::chrono::milliseconds(50));
                     continue;
                 }
-                std::cout << "got completion queue event #" << tag << " => " << (ok ? "ok" : "not ok") << std::endl;
+                // std::cout << "got completion queue event #" << tag << " => " << (ok ? "ok" : "not ok") << std::endl;
                 auto &token = callbacks.at(reinterpret_cast<size_t>(tag));
                 co_await token.sequenced_set_result(ok);
             }
             std::cout << "stopping completion queue" << std::endl;
+            co_return;
         }
 
         template<typename Rpc, typename Response>

--- a/src/grpc_client_wrapper_async.cpp
+++ b/src/grpc_client_wrapper_async.cpp
@@ -11,7 +11,7 @@
 #include "cppcoro/sync_wait.hpp"
 
 namespace SteamClient {
-    struct grpc_client_wrapper_async::impl {
+    struct AsyncClientWrapper::impl {
         std::shared_ptr<grpc::Channel> channel;
         std::unique_ptr<steam::AuthService::Stub> authStub;
         std::unique_ptr<steam::MessageService::Stub> messageStub;
@@ -239,29 +239,29 @@ namespace SteamClient {
     };
 
     cppcoro::task<AuthResponseState>
-    grpc_client_wrapper_async::authenticate(const std::string &username, const std::string &password,
-                                            const std::optional<std::string> &steamGuardCode) {
+    AsyncClientWrapper::authenticate(const std::string &username, const std::string &password,
+                                     const std::optional<std::string> &steamGuardCode) {
         return pImpl->authenticate(username, password, steamGuardCode);
     }
 
-    cppcoro::task<FriendsList> grpc_client_wrapper_async::getFriendsList() {
+    cppcoro::task<FriendsList> AsyncClientWrapper::getFriendsList() {
         return pImpl->getFriendsList();
     }
 
     cppcoro::task<std::vector<Message>>
-    grpc_client_wrapper_async::getMessages(const std::string &id, std::optional<int64_t> startTimestampNs,
-                                           std::optional<int64_t> lastTimestampNs) {
+    AsyncClientWrapper::getMessages(const std::string &id, std::optional<int64_t> startTimestampNs,
+                                    std::optional<int64_t> lastTimestampNs) {
         return pImpl->getMessages(id, startTimestampNs, lastTimestampNs);
     }
 
     cppcoro::task<SendMessageCode>
-    grpc_client_wrapper_async::sendMessage(const std::string &id, const std::string &message) {
+    AsyncClientWrapper::sendMessage(const std::string &id, const std::string &message) {
         return pImpl->sendMessage(id, message);
     }
 
-    grpc_client_wrapper_async::grpc_client_wrapper_async::grpc_client_wrapper_async(const std::string &address) {
+    AsyncClientWrapper::AsyncClientWrapper::AsyncClientWrapper(const std::string &address) {
         pImpl = std::make_unique<impl>(address);
     }
 
-    grpc_client_wrapper_async::~grpc_client_wrapper_async() = default;
+    AsyncClientWrapper::~AsyncClientWrapper() = default;
 } // SteamClient

--- a/src/grpc_client_wrapper_async.cpp
+++ b/src/grpc_client_wrapper_async.cpp
@@ -247,18 +247,27 @@ namespace SteamClient {
     }
 
     cppcoro::task<FriendsList> AsyncClientWrapper::getFriendsList() {
+        _check_session_key();
         return pImpl->getFriendsList();
     }
 
     cppcoro::task<std::vector<Message>>
     AsyncClientWrapper::getMessages(const std::string &id, std::optional<int64_t> startTimestampNs,
                                     std::optional<int64_t> lastTimestampNs) {
+        _check_session_key();
         return pImpl->getMessages(id, startTimestampNs, lastTimestampNs);
     }
 
     cppcoro::task<SendMessageCode>
     AsyncClientWrapper::sendMessage(const std::string &id, const std::string &message) {
+        _check_session_key();
         return pImpl->sendMessage(id, message);
+    }
+
+    void AsyncClientWrapper::_check_session_key() {
+        if (!isSessionKeySet()) {
+            throw std::runtime_error("session key not set");
+        }
     }
 
     void AsyncClientWrapper::resetSessionKey() {
@@ -267,6 +276,10 @@ namespace SteamClient {
 
     bool AsyncClientWrapper::shouldReset() {
         return !pImpl->lastSuccessState;
+    }
+
+    bool AsyncClientWrapper::isSessionKeySet() {
+        return pImpl->sessionKey.has_value();
     }
 
     AsyncClientWrapper::AsyncClientWrapper::AsyncClientWrapper(const std::string &address) {

--- a/src/grpc_client_wrapper_async.h
+++ b/src/grpc_client_wrapper_async.h
@@ -6,6 +6,7 @@
 #include <vector>
 #include <memory>
 #include "cppcoro/task.hpp"
+#include "cppcoro/io_service.hpp"
 
 namespace SteamClient {
     class AsyncClientWrapper {
@@ -18,6 +19,10 @@ namespace SteamClient {
         explicit AsyncClientWrapper(const std::string &address);
 
         ~AsyncClientWrapper();
+
+        cppcoro::task<void> run_cq(cppcoro::io_service &ioService);
+
+        void shutdown();
 
         cppcoro::task <AuthResponseState> authenticate(const std::string &username, const std::string &password,
                                                        const std::optional<std::string> &steamGuardCode);

--- a/src/grpc_client_wrapper_async.h
+++ b/src/grpc_client_wrapper_async.h
@@ -35,7 +35,7 @@ namespace SteamClient {
 
         cppcoro::task <SendMessageCode> sendMessage(const std::string &id, const std::string &message);
 
-        cppcoro::task <ActiveMessageSessions> getActiveMessageSessions(int64_t sinceTimestampMs);
+        cppcoro::task <ActiveMessageSessions> getActiveMessageSessions(std::optional<int64_t> sinceTimestampMs = std::nullopt);
 
         cppcoro::task<bool> ackFriendMessage(const std::string &id, int64_t timestampNs);
 

--- a/src/grpc_client_wrapper_async.h
+++ b/src/grpc_client_wrapper_async.h
@@ -12,6 +12,8 @@ namespace SteamClient {
         struct impl;
         std::unique_ptr<impl> pImpl;
 
+        void _check_session_key();
+
     public:
         explicit AsyncClientWrapper(const std::string &address);
 
@@ -31,6 +33,8 @@ namespace SteamClient {
         void resetSessionKey();
 
         bool shouldReset();
+
+        bool isSessionKeySet();
     };
 } // SteamClient
 

--- a/src/grpc_client_wrapper_async.h
+++ b/src/grpc_client_wrapper_async.h
@@ -8,14 +8,14 @@
 #include "cppcoro/task.hpp"
 
 namespace SteamClient {
-    class grpc_client_wrapper_async {
+    class AsyncClientWrapper {
         struct impl;
         std::unique_ptr<impl> pImpl;
 
     public:
-        explicit grpc_client_wrapper_async(const std::string &address);
+        explicit AsyncClientWrapper(const std::string &address);
 
-        ~grpc_client_wrapper_async();
+        ~AsyncClientWrapper();
 
         cppcoro::task <AuthResponseState> authenticate(const std::string &username, const std::string &password,
                                                        const std::optional<std::string> &steamGuardCode);

--- a/src/grpc_client_wrapper_async.h
+++ b/src/grpc_client_wrapper_async.h
@@ -35,6 +35,10 @@ namespace SteamClient {
 
         cppcoro::task <SendMessageCode> sendMessage(const std::string &id, const std::string &message);
 
+        cppcoro::task <ActiveMessageSessions> getActiveMessageSessions(int64_t sinceTimestampMs);
+
+        cppcoro::task<bool> ackFriendMessage(const std::string &id, int64_t timestampNs);
+
         void resetSessionKey();
 
         bool shouldReset();

--- a/src/grpc_client_wrapper_async.h
+++ b/src/grpc_client_wrapper_async.h
@@ -1,0 +1,34 @@
+#ifndef PIDGIN_STEAM_GRPC_CLIENT_WRAPPER_ASYNC_H
+#define PIDGIN_STEAM_GRPC_CLIENT_WRAPPER_ASYNC_H
+
+#include <string>
+#include <optional>
+#include <vector>
+#include <memory>
+#include "cppcoro/task.hpp"
+
+namespace SteamClient {
+    class grpc_client_wrapper_async {
+        struct impl;
+        std::unique_ptr<impl> pImpl;
+
+    public:
+        explicit grpc_client_wrapper_async(const std::string &address);
+
+        ~grpc_client_wrapper_async();
+
+        cppcoro::task <AuthResponseState> authenticate(const std::string &username, const std::string &password,
+                                                       const std::optional<std::string> &steamGuardCode);
+
+        cppcoro::task <FriendsList> getFriendsList();
+
+        cppcoro::task <std::vector<Message>>
+        getMessages(const std::string &id, std::optional<int64_t> startTimestampNs = std::nullopt,
+                    std::optional<int64_t> lastTimestampNs = std::nullopt);
+
+        cppcoro::task <SendMessageCode> sendMessage(const std::string &id, const std::string &message);
+
+    };
+} // SteamClient
+
+#endif //PIDGIN_STEAM_GRPC_CLIENT_WRAPPER_ASYNC_H

--- a/src/grpc_client_wrapper_async.h
+++ b/src/grpc_client_wrapper_async.h
@@ -28,6 +28,9 @@ namespace SteamClient {
 
         cppcoro::task <SendMessageCode> sendMessage(const std::string &id, const std::string &message);
 
+        void resetSessionKey();
+
+        bool shouldReset();
     };
 } // SteamClient
 

--- a/src/grpc_exp.cpp
+++ b/src/grpc_exp.cpp
@@ -6,7 +6,11 @@
 #include <string>
 #include <optional>
 #include <fstream>
+#include <thread>
 #include "json/json.h"
+#include "cppcoro/cancellation_source.hpp"
+#include "cppcoro/async_scope.hpp"
+#include "cppcoro/when_all_ready.hpp"
 
 void sync() {
     SteamClient::ClientWrapper client("localhost:8080");
@@ -21,12 +25,24 @@ void sync() {
     }
 }
 
+struct Driver {
+    cppcoro::io_service ioService;
+    // cppcoro::async_scope scope;
+    cppcoro::cancellation_source cancelTokenSource;
+    cppcoro::cancellation_token cancelToken = cancelTokenSource.token();
+};
+
+
 cppcoro::task<void>
-async_task(SteamClient::AsyncClientWrapper &client, std::string username, std::string password) {
+async_task(Driver &driver, SteamClient::AsyncClientWrapper &client, std::string username, std::string password) {
+    cppcoro::io_work_scope ioScope(driver.ioService);
+
     std::cout << "async_task start" << std::endl;
     std::cout << "auth result: " << co_await client.authenticate(username, password, std::nullopt) << "\n";
-    std::cout << "async_task end" << std::endl;
+
+    std::cout << "Get friends list" << std::endl;
     auto friends = co_await client.getFriendsList();
+    std::cout << "Get all messages" << std::endl;
     for (auto &x: friends.buddies) {
         std::cout << x.nickname << " " << x.id << std::endl;
         std::vector<SteamClient::Message> messages = co_await client.getMessages(x.id);
@@ -34,16 +50,29 @@ async_task(SteamClient::AsyncClientWrapper &client, std::string username, std::s
             std::cout << y.senderId << " " << y.message << " " << y.timestamp_ns << std::endl;
         }
     }
+
+    std::cout << "Get active chat sessions" << std::endl;
+    auto sessions = co_await client.getActiveMessageSessions();
+    for (auto &x: sessions.session) {
+        std::cout << x.id << " " << x.lastMessageTimestampNs << " " << x.lastViewedTimestampNs << " "
+                  << x.unreadMessageCount << std::endl;
+    }
+
+    std::cout << "async_task shutdown" << std::endl;
+    client.shutdown();
+    driver.cancelTokenSource.request_cancellation();
+
+    std::cout << "async_task end" << std::endl;
     co_return;
 }
 
-void async() {
+cppcoro::task<void> async_driver() {
     std::ifstream file("/tmp/credentials.json", std::ifstream::binary);
     Json::Value root;
     Json::Reader reader;
     if (!reader.parse(file, root)) {
         std::cout << "Failed to parse configuration\n" << reader.getFormattedErrorMessages();
-        return;
+        co_return;
     }
 
     SteamClient::AsyncClientWrapper client("localhost:8080");
@@ -52,7 +81,46 @@ void async() {
     std::cout << "username: " << username << std::endl;
     std::cout << "password: " << password << std::endl;
     std::cout << "async start" << std::endl;
-    cppcoro::sync_wait(std::move(async_task(client, username, password)));
+
+    Driver driver;
+    co_await cppcoro::when_all_ready(
+            [&]() -> cppcoro::task<void> {
+                cppcoro::io_work_scope ioScope(driver.ioService);
+                co_await client.run_cq(driver.ioService);
+                co_return;
+            }(),
+            async_task(driver, client, username, password),
+            [&driver]() -> cppcoro::task<void> {
+                driver.ioService.process_events();
+                co_return;
+            }());
+    co_return;
+
+    /*
+    Driver driver;
+    driver.scope.spawn(client.run_cq(driver.ioService));
+    driver.scope.spawn([=, &driver, &client]() -> cppcoro::task<void> {
+        co_await async_task(driver, client, username, password);
+        std::cout << "async_task shutdown start" << std::endl;
+        client.shutdown();
+        driver.cancelTokenSource.request_cancellation();
+        driver.ioService.stop();
+        std::cout << "async_task end" << std::endl;
+    }());
+    std::thread thread([&]() {
+        std::cout << "thread start" << std::endl;
+        driver.ioService.process_events();
+        std::cout << "thread end" << std::endl;
+    });
+    // cppcoro::sync_wait(std::move(async_task(driver, client, username, password)));
+    std::cout << "Joining async scope" << std::endl;
+    co_await driver.scope.join();
+    std::cout << "async end" << std::endl;
+    */
+}
+
+void async() {
+    cppcoro::sync_wait(async_driver());
 }
 
 int main() {

--- a/src/grpc_exp.cpp
+++ b/src/grpc_exp.cpp
@@ -22,7 +22,7 @@ void sync() {
 }
 
 cppcoro::task<void>
-async_task(SteamClient::grpc_client_wrapper_async &client, std::string username, std::string password) {
+async_task(SteamClient::AsyncClientWrapper &client, std::string username, std::string password) {
     std::cout << "async_task start" << std::endl;
     std::cout << "auth result: " << co_await client.authenticate(username, password, std::nullopt) << "\n";
     std::cout << "async_task end" << std::endl;
@@ -46,7 +46,7 @@ void async() {
         return;
     }
 
-    SteamClient::grpc_client_wrapper_async client("localhost:8080");
+    SteamClient::AsyncClientWrapper client("localhost:8080");
     auto username = EnvVars::get("STEAM_USERNAME")().value_or(root["username"].asString());
     auto password = EnvVars::get("STEAM_PASSWORD")().value_or(root["password"].asString());
     std::cout << "username: " << username << std::endl;

--- a/src/grpc_exp.cpp
+++ b/src/grpc_exp.cpp
@@ -1,10 +1,14 @@
 #include "grpc_client_wrapper.h"
 #include "environ.h"
+#include "grpc_client_wrapper_async.h"
+#include "cppcoro/sync_wait.hpp"
 #include <iostream>
 #include <string>
 #include <optional>
+#include <fstream>
+#include "json/json.h"
 
-int main() {
+void sync() {
     SteamClient::ClientWrapper client("localhost:8080");
     client.authenticate(EnvVars::get("STEAM_USERNAME").value(), EnvVars::get("STEAM_PASSWORD").value(), std::nullopt);
     auto friends = client.getFriendsList();
@@ -15,5 +19,43 @@ int main() {
             std::cout << y.senderId << " " << y.message << " " << y.timestamp_ns << std::endl;
         }
     }
+}
+
+cppcoro::task<void>
+async_task(SteamClient::grpc_client_wrapper_async &client, std::string username, std::string password) {
+    std::cout << "async_task start" << std::endl;
+    std::cout << "auth result: " << co_await client.authenticate(username, password, std::nullopt) << "\n";
+    std::cout << "async_task end" << std::endl;
+    auto friends = co_await client.getFriendsList();
+    for (auto &x: friends.buddies) {
+        std::cout << x.nickname << " " << x.id << std::endl;
+        std::vector<SteamClient::Message> messages = co_await client.getMessages(x.id);
+        for (auto &y: messages) {
+            std::cout << y.senderId << " " << y.message << " " << y.timestamp_ns << std::endl;
+        }
+    }
+    co_return;
+}
+
+void async() {
+    std::ifstream file("/tmp/credentials.json", std::ifstream::binary);
+    Json::Value root;
+    Json::Reader reader;
+    if (!reader.parse(file, root)) {
+        std::cout << "Failed to parse configuration\n" << reader.getFormattedErrorMessages();
+        return;
+    }
+
+    SteamClient::grpc_client_wrapper_async client("localhost:8080");
+    auto username = EnvVars::get("STEAM_USERNAME")().value_or(root["username"].asString());
+    auto password = EnvVars::get("STEAM_PASSWORD")().value_or(root["password"].asString());
+    std::cout << "username: " << username << std::endl;
+    std::cout << "password: " << password << std::endl;
+    std::cout << "async start" << std::endl;
+    cppcoro::sync_wait(std::move(async_task(client, username, password)));
+}
+
+int main() {
+    async();
     return 0;
 }

--- a/src/libdummy.cpp
+++ b/src/libdummy.cpp
@@ -126,6 +126,7 @@ cppcoro::task<std::optional<int64_t>> poll_friend_messages(SteamAccount &sa, con
     auto sbuddy = static_cast<SteamBuddy *>(buddy->proto_data);  // TODO
     sbuddy->gameextrainfo = x.gameExtraInfo;
     sbuddy->gameid = x.gameid;
+    sbuddy->avatarUrl = x.avatarUrl.icon;
 
     auto otherId = x.id;
     PurpleConversation *conv = purple_find_conversation_with_account(PURPLE_CONV_TYPE_IM, otherId.c_str(),

--- a/src/libdummy.cpp
+++ b/src/libdummy.cpp
@@ -394,7 +394,7 @@ static unsigned int steam_send_typing(PurpleConnection *pc, const gchar *name, P
 }
 
 cppcoro::task<void> attempt_login(PurpleConnection *pc, SteamAccount &sa) {
-    purple_debug_info("debug", "steam_login with creds %s %s\n", sa.username.c_str(), sa.password.c_str());
+    purple_debug_info("debug", "steam_login with creds %s\n", sa.username.c_str());
 
     purple_connection_set_state(pc, PURPLE_CONNECTING);
     purple_connection_update_progress(pc, _("Connecting"), 1, 3);

--- a/src/libdummy.cpp
+++ b/src/libdummy.cpp
@@ -222,22 +222,29 @@ gboolean poll_for_messages(PurpleConnection *pc) {
 
 cppcoro::task<int> send_message(PurpleConnection *pc, SteamAccount &sa, const std::string &who, const std::string &msg) {
     purple_debug_info("dummy", "send_message with %s %s\n", who.c_str(), msg.c_str());
+    // TODO: better error handling
     switch (co_await sa.client.sendMessage(who, msg)) {
         case SteamClient::SEND_SUCCESS:
             co_return 0;
         case SteamClient::SEND_INVALID_SESSION_KEY:
+            purple_notify_warning(pc, "Session Issue", "Session Issue",
+                                  "There seems to be an issue with your current session. Please log out and log back in again.");
             purple_connection_error_reason(pc, PURPLE_CONNECTION_ERROR_AUTHENTICATION_FAILED,
                                            "Invalid session key");
             co_return -ENOTCONN;
         case SteamClient::SEND_INVALID_TARGET_ID:
-            purple_connection_error_reason(pc, PURPLE_CONNECTION_ERROR_AUTHENTICATION_FAILED,
-                                           "Invalid target ID");
+            purple_debug_warning("dummy", "send_message invalid target ID %s\n", who.c_str());
+            // purple_connection_error_reason(pc, PURPLE_CONNECTION_ERROR_AUTHENTICATION_FAILED,
+            //                                "Invalid target ID");
             co_return -1;
         case SteamClient::SEND_INVALID_MESSAGE:
-            purple_connection_error_reason(pc, PURPLE_CONNECTION_ERROR_AUTHENTICATION_FAILED,
-                                           "Invalid message");
+            purple_debug_warning("dummy", "send_message invalid message %s\n", msg.c_str());
+            // purple_connection_error_reason(pc, PURPLE_CONNECTION_ERROR_AUTHENTICATION_FAILED,
+            //                                "Invalid message");
             co_return -2;
         case SteamClient::SEND_UNKNOWN_FAILURE:
+            purple_notify_warning(pc, "Session Issue", "Session Issue",
+                                  "There seems to be an issue with your current session. Please log out and log back in again.");
             purple_connection_error_reason(pc, PURPLE_CONNECTION_ERROR_AUTHENTICATION_FAILED,
                                            "Unknown error");
             co_return -3;

--- a/src/libdummy.h
+++ b/src/libdummy.h
@@ -52,6 +52,10 @@
 #include "sslconn.h"
 #include "version.h"
 #include "grpc_client_wrapper.h"
+#include "grpc_client_wrapper_async.h"
+#include "cppcoro/async_scope.hpp"
+#include "cppcoro/io_service.hpp"
+#include "cppcoro/cancellation_source.hpp"
 #include <sys/stat.h>
 
 
@@ -136,8 +140,11 @@ struct SteamAccount {
     std::map<std::string, int64_t> lastMessageTimestamps;  // TODO: refactor to per-buddy state
 
     // for stub implementation
-    SteamClient::ClientWrapper client = SteamClient::ClientWrapper("localhost:8080");
-    guint poll_callback_id;
+    SteamClient::AsyncClientWrapper client{"localhost:8080"};
+    cppcoro::cancellation_source cancelTokenSource;
+    cppcoro::cancellation_token cancelToken;
+    cppcoro::async_scope scope;
+    cppcoro::io_service ioService;
 
     // custom memory allocator
     static void *operator new(size_t size) {

--- a/src/libdummy.h
+++ b/src/libdummy.h
@@ -166,7 +166,7 @@ struct SteamBuddy {
     std::string realname;
     std::string profileurl;
     guint lastlogoff;
-    std::string avatar;
+    std::string avatarUrl;
     guint personastateflags;
 
     std::optional<int> gameid;

--- a/src/libdummy.h
+++ b/src/libdummy.h
@@ -141,6 +141,7 @@ struct SteamAccount {
 
     // for stub implementation
     SteamClient::AsyncClientWrapper client{"localhost:8080"};
+    guint poll_callback_id;
     cppcoro::cancellation_source cancelTokenSource;
     cppcoro::cancellation_token cancelToken;
     cppcoro::async_scope scope;

--- a/src/libdummy.h
+++ b/src/libdummy.h
@@ -65,6 +65,7 @@
 #include <map>
 #include <optional>
 #include <stdexcept>
+#include <semaphore>
 
 #if GLIB_MAJOR_VERSION >= 2 && GLIB_MINOR_VERSION >= 12
 #	define atoll(a) g_ascii_strtoll(a, NULL, 0)


### PR DESCRIPTION
Implements an asynchronous gRPC client (`SteamClient::AsyncClientWrapper`) and uses it in the `libdummy` plugin. This fixes freezing when waiting for gRPC responses.
The asynchronous code runs is driven by the GTK event loop since Pidgin expects certain callbacks to run in Pidgin's thread, but the cleanup sometimes crashes when Pidgin exits.

Other changes:
* Handle a larger number of friends by polling messages for only friends that have unacknowledged messages (using `FriendMessages.GetActiveMessageSessions#1`)
* Acknowledge messages after polling
* Update gRPC demo script (`src/grpc_exp.cpp`)
* Bump dependencies